### PR TITLE
Added url. FIX for share buttons.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,8 @@ description: >-
   Česká pirátská strana - Krajské sdružení Středočeský kraj
 # dobré keywords jsou ty co lidé piší do googlu když hledají naši stránku
 keywords: krajské sdružení, střední čechy, středočeši, piráti, česká pirátská strana, politická strana, politika, demokracie, svoboda, otevřenost, transparentnost 
+baseurl: "" # the subpath of your site, e.g. /blog
+url: "https://stredocesky.pirati.cz" # the base hostname & protocol for your site
 
 administrator:
   email: jan.korbel@pirati.cz,vaclav.kubaljak@pirati.cz # mail kam pujdou chybove vystupy


### PR DESCRIPTION
Share buttony u článků nefungují. Podávají pouze relativní odkaz a FB i TW chtějí absolutní. Přišl jsem na to při rozchození kladna. TO podalo tento fix a pro kladno funguje. Zde jsem to na lokálu netestoval, ale je to imho prosté... 

Parametr chybí už v examplu a stejnou chybu tak mají i další weby, používající tento základ. Namátkou minimálně ještě vysočina. Reportoval jsem to TO ... U SčK to stále trvá a tak ti to posílám přímo ... 

